### PR TITLE
Fix raise on non-200 status code

### DIFF
--- a/lib/pager_duty/connection.rb
+++ b/lib/pager_duty/connection.rb
@@ -152,10 +152,6 @@ module PagerDuty
 
         conn.authorization(token_type, token)
 
-        conn.use RaiseApiErrorOnNon200
-        conn.use RaiseFileNotFoundOn404
-        conn.use RaiseRateLimitOn429
-
         conn.use ConvertTimesParametersToISO8601
 
         # use json
@@ -167,6 +163,13 @@ module PagerDuty
         conn.response :mashify
         conn.response :json
         conn.response :logger, ::Logger.new(STDOUT), bodies: true if debug
+
+        # Because Faraday::Middleware executes in reverse order of
+        # calls to conn.use, status code error handling goes at the
+        # end of the block so that it runs first
+        conn.use RaiseApiErrorOnNon200
+        conn.use RaiseFileNotFoundOn404
+        conn.use RaiseRateLimitOn429
 
         conn.adapter  Faraday.default_adapter
       end


### PR DESCRIPTION
The execution order of Faraday::Middleware passed to conn.use in the Faraday.new block is the reverse order of the calls to conn.use (i.e. if conn.use Klass comes last it will run first). Because the time string parsing middleware raises on the body when the status code is 401, and because ParseTimeStrings executes before RaiseApiErrorOnNon200, the raise for a non-200 status code never happens.

Moving the error status code handling middleware to the end of the block ensures that they execute first.